### PR TITLE
Refactor the Response data formate of Search Query Results

### DIFF
--- a/src/controllers/home.controller.ts
+++ b/src/controllers/home.controller.ts
@@ -63,8 +63,13 @@ export const getSearchResults = asyncHandler(
           { expertise: { $in: searchQuery } },
           { expertise: { $elemMatch: { $in: [searchQuery] } } },
         ],
-      });
-
+      })
+      .select('ratings expertise _id userId profilePicture').limit(10)
+      .populate({
+        path: 'userId',
+        model:'User',
+        select: 'name',
+      });     
       return res.json(new ApiResponse(ResponseStatusCode.SUCCESS, paraExperts));
     } catch (error) {
       return res.json(


### PR DESCRIPTION
### Endpoint: baseurl/api/v1/home/search/Query


This request is to update the getSearchResults API to enhance the efficiency and relevancy of the data returned in the search results

- Limit the returned fields to only the necessary ones: rating, expertise, _id, userId, and profilePicture.
- Populate the userId field with only the name field from the associated user document.

<img width="1001" alt="Screenshot 2024-07-02 at 3 04 12 PM" src="https://github.com/paratalks/para-back/assets/122713145/c9011e77-dd52-4545-bd57-c58430a05f2d">
