### PR TITLE
feat: Created upload payment receipt API using AWS S3 bucket

### DIFF
--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -4,6 +4,8 @@ import crypto from "node:crypto";
 import { Payment } from "../models/payment/payment.model";
 import { ApiResponse } from "../util/apiResponse";
 import { ResponseStatusCode } from "../constants/constants";
+import { ApiError } from "../util/apiError";
+import { S3Client,PutObjectCommand,GetObjectCommand } from '@aws-sdk/client-s3';
 
 export const checkout = async (req: Request, res: Response) => {
   const options = {
@@ -44,5 +46,47 @@ export const paymentVerification = async (req: Request, res: Response) => {
     }
   } catch (error) {
     res.json(new ApiResponse(ResponseStatusCode.INTERNAL_SERVER_ERROR, "internal server error"))
+  }
+};
+
+const s3Client = new S3Client({
+  region: process.env.AWS_REGION!,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!
+  }
+});
+
+const bucketName = process.env.AWS_S3_BUCKET_NAME!;
+//upload payment receipt
+export const uploadPaymentReceipt = async (req: Request, res: Response) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json(new ApiResponse(ResponseStatusCode.BAD_REQUEST, null, 'No file uploaded'));
+    }
+
+    const filename = `${Date.now()}-${req.file.originalname}`;
+    const contentType = req.file.mimetype;
+    const fileContent = req.file.buffer;
+
+    const putCommand = new PutObjectCommand({
+      Bucket: bucketName,
+      Key: `uploads/payment-receipt/${filename}`,
+      Body: fileContent,
+      ContentType: contentType,
+      ACL: 'public-read',
+    });
+
+    await s3Client.send(putCommand);
+
+    const fileUrl = `https://${bucketName}.s3.${process.env.AWS_REGION!}.amazonaws.com/uploads/payment-receipt/${filename}`;
+
+    return res.json(new ApiResponse(ResponseStatusCode.SUCCESS, fileUrl, "payment receipt Uploaded successfully"));
+  } catch (error) {
+    console.error('Error uploading file:', error);
+    throw new ApiError(
+      ResponseStatusCode.INTERNAL_SERVER_ERROR,
+      error.message || "Internal server error"
+    );
   }
 };

--- a/src/routes/v1/payment.route.ts
+++ b/src/routes/v1/payment.route.ts
@@ -1,9 +1,13 @@
 import express from "express";
-import { checkout, paymentVerification } from "../../controllers/payment.controller";
+import { checkout, paymentVerification, uploadPaymentReceipt } from "../../controllers/payment.controller";
+import multer from 'multer';
 
 const router = express.Router();
+const upload = multer({ storage: multer.memoryStorage() });
+const uploadFile = (fieldName: string) => upload.single(fieldName);
 
 router.route("/checkout").post(checkout)
 router.route("/verification").post(paymentVerification)
+router.patch('/uploadPaymentReceipt', uploadFile('paymentReceipt'),uploadPaymentReceipt);
 
 export default router;


### PR DESCRIPTION
- Implemented an API endpoint '/uploadPaymentReceipt/:userId' to handle payment receipt uploads.
- Integrated AWS S3 for storing uploaded payment receipts.
- Used 'uploadFile' middleware to process file uploads and store them in the 'paymentReceipt' directory in S3.
